### PR TITLE
fix: adjust list margins in CSS

### DIFF
--- a/assets/css/_reset.scss
+++ b/assets/css/_reset.scss
@@ -32,11 +32,8 @@ body {
 	line-height: 1;
 }
 ol, ul {
-	list-style: none;
+	list-style-type: "* ";
 	padding-left: 2ch;
-}
-li:before {
-    content: "* ";
 }
 blockquote, q {
 	quotes: none;


### PR DESCRIPTION
# Adjust list margins in CSS

Currently, lists across the website have indentation — a left margin — instead of aligning with the rest of the layout elements. Additionally, when the text of a list item is too long and wraps onto a second line, the second line's text becomes misaligned with the first.

This pull request fixes these issues.

<img width="786" alt="image" src="https://github.com/user-attachments/assets/b47531d8-9c25-48ba-aef5-405b22cb24a6" />
