### PR TITLE
fix: normalize paragraph spacing in post content

### DIFF
--- a/assets/css/_post.scss
+++ b/assets/css/_post.scss
@@ -24,4 +24,24 @@
       }
     }
   }
+
+  &-content {
+    li > p {
+      margin-bottom: 0;
+    }
+
+    > ul > li {
+      margin-bottom: 0.75rem;
+    }
+
+    ul ul {
+      margin-top: 0.25rem;
+      margin-bottom: 0;
+      padding-left: 2ch;
+    }
+
+    h2 {
+      margin-top: 2rem;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `.Post-content` CSS rules to normalize list item spacing in post pages
- Fixes uneven vertical rhythm caused by kramdown wrapping some `<li>` contents in `<p>` tags (loose lists) but not others
- Increases `h2` top margin for clearer section breaks

## Test plan
- [x] Verified locally with `make preview` on http://localhost:4000/2026-04-29-socratic-seminar-24
- [x] Check that "Tópicos Bitcoin" items have uniform spacing
- [x] Verify "Avisos" and "Agradecimentos" compact lists still look correct
- [x] Test both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)